### PR TITLE
comment: fix brief/description separation during parsing

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -23,7 +23,13 @@ pub fn parse_comment(string: String) -> Option<Comment> {
     let mut brief = String::new();
     while let Some(line) = lines.next() {
         let trimmed = line.trim();
-        if trimmed.is_empty() {
+        let cleaned = if trimmed.starts_with("//<") {
+            remove_prefix_and_clean(trimmed, "//<")
+        } else {
+            remove_prefix_and_clean(trimmed, "///")
+        };
+
+        if cleaned.is_empty() {
             break;
         }
 
@@ -31,11 +37,7 @@ pub fn parse_comment(string: String) -> Option<Comment> {
             brief.push(' ');
         }
 
-        if trimmed.starts_with("///<") {
-            brief.push_str(&remove_prefix_and_clean(trimmed, "///<"));
-        } else {
-            brief.push_str(&remove_prefix_and_clean(trimmed, "///"));
-        }
+        brief.push_str(&cleaned);
     }
 
     ret.brief = brief;


### PR DESCRIPTION
When writing a multi-paragraph comment like this:

```c++
/// An owning bitmap image representation, provides methods to load and save
/// images from and to files.
///
/// It is a container that *owns* the pixel data of the image, which means it is
/// responsible for allocating and deallocating the memory used to store the
/// pixels.
///
/// This class should not be used to *access* the pixels. For this, use the
/// lightweight `Pixels2D` class instead, which can be constructed using the
/// `to_pixels2D()` method of this class.
class BitmapData {
// ...
}
```

The whole comment is being stored in the "brief" part of the documentation, and in turn displayed as a one very long line in entity listings. This happens because the `parse_comment()` function is looking for the end of the brief by checking if the current line is empty after trimming *but before removing the comment prefix*, so it concludes that there are no empty line and that everything is the brief.

With this PR, the part of the `parse_comment()` function that handles the brief now starts by trimming *and cleaning* the current line, before checking if it is empty.

Note that I also changed the `///<` inline prefix to `//<` to make it match what is advertised in [USAGE.md#comments](https://github.com/rdmsr/cppdoc/blob/master/USAGE.md#comments), but let me know if you prefer that I make separate commit or PR for this, or if you want me to change `USAGE.md` to match what the code does instead!