### PR TITLE
parser: fix fields being attributed the struct/enum's description

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -238,7 +238,7 @@ impl<'a> Parser<'a> {
         for c in node.get_children().iter() {
             match c.get_kind() {
                 clang::EntityKind::FieldDecl => if let Some(clang::Accessibility::Public) = c.get_accessibility() {
-                    let comment = if let Some(comment) = node.get_comment() {
+                    let comment = if let Some(comment) = c.get_comment() {
                         comment::parse_comment(comment)
                     } else {
                         None
@@ -371,7 +371,7 @@ impl<'a> Parser<'a> {
 
         for c in node.get_children().iter() {
             if c.get_kind() == clang::EntityKind::EnumConstantDecl {
-                let comment = if let Some(comment) = node.get_comment() {
+                let comment = if let Some(comment) = c.get_comment() {
                     comment::parse_comment(comment)
                 } else {
                     None


### PR DESCRIPTION
When generating the documentation for the fields of an enum or struct, cppdoc currently copies the documentation of the parent entity itself instead of using the possibly-provided field doc comment (or instead of leaving it empty if there is no doc comment for a field). This seems like a typo in the code, I fixed the ones I found but I may have missed other similar errors elsewhere. I'll make a new PR if I find more.