### PR TITLE
[bugfix]: Added explicit error reporting of missing "book" section.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -341,7 +341,13 @@ fn main() {
 
             if let Some(book_dir) = pages_config.and_then(|p| p.book.as_ref()) {
                 let path = std::path::Path::new(book_dir).join("SUMMARY.md");
-                let contents = std::fs::read_to_string(path).unwrap();
+                let contents = match std::fs::read_to_string(&path) {
+                    Ok(c) => c,
+                    Err(_) => {
+                        report_error(&format!("Could not find book dir summary file: {:?}", path));
+                        "".into()
+                    }
+                };
                 summary = book::parse_summary(&contents, book_dir);
             }
 


### PR DESCRIPTION
When using duck, if the example duck.toml is used without a summary file in the `book` directory:

```
[pages]
index = "README.md"
book = "extra-pages" < This one here
```

Then duck will report a failed unwrap on line 344, specifying an OSError.

For an early adopter, this can make it hard to nail down what exactly went wrong. Reporting explicitly what happened make it very clear.